### PR TITLE
:pushpin: Fix quarkus dependency version according to GraalVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0-SNAPSHOT</version>
   <properties>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>0.13.1</quarkus.version>
+    <quarkus.version>0.15.0</quarkus.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -9,7 +9,7 @@
 ###
 
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/centos-quarkus-maven AS build
+FROM quay.io/quarkus/centos-quarkus-maven:graalvm-1.0.0-rc15 AS build
 COPY src /usr/src/app/src
 COPY pom.xml /usr/src/app
 # we will build a native image using the native maven profile


### PR DESCRIPTION
The tag of quay.io/quarkus/centos-quarkus-maven used in the multistage Dockerfile was latest.
The version of the maven io.quarkus:quarkus-bom dependency was 0.13.1.

These 2 versions are not compatible to produce a native application.
I fixed the version of the io.quarkus:quarkus-bom dependency to 0.15.0 and the version of the quay.io/quarkus/centos-quarkus-maven docker image to rc15.

By this way, the build docker image is now (and will always be) compatible with the maven dependency.