### PR TITLE
:white_check_mark: use H2 DB to allow unit testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,17 @@
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
 
+
     <!-- tests -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-h2</artifactId>
+      <version>${quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus-demo.iml
+++ b/quarkus-demo.iml
@@ -7,10 +7,67 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-resteasy:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-undertow:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-arc:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus.arc:arc:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-resteasy-server-common:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-resteasy-common:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jboss.resteasy:resteasy-core:4.0.0.Final" level="project" />
+    <orderEntry type="library" name="Maven: org.jboss.resteasy:resteasy-core-spi:4.0.0.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-jaxb:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-resteasy-jsonb:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-jsonb:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-jsonp:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jboss.resteasy:resteasy-json-binding-provider:4.0.0.Final" level="project" />
+    <orderEntry type="library" name="Maven: org.jboss.resteasy:resteasy-json-p-provider:4.0.0.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-hibernate-orm:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-core:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jboss.threads:jboss-threads:3.0.0.Beta3" level="project" />
+    <orderEntry type="library" name="Maven: org.graalvm.sdk:graal-sdk:1.0.0-rc16" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-ssl:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-auth-server:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-permission:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-base:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-credential:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-keystore:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-provider-util:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-auth:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-util:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-x500:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-x500-cert:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-asn1:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: org.wildfly.security:wildfly-elytron-x500-cert-util:2.0.0.Alpha4" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-agroal:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-narayana-jta:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-caffeine:0.15.0" level="project" />
+    <orderEntry type="library" name="Maven: io.quarkus:quarkus-jdbc-postgresql:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-test-h2:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-test-common:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-core-deployment:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-beanutils:commons-beanutils:1.9.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-builder:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-jsonp-deployment:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.197" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-junit5:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-bootstrap-core:0.15.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven:maven-embedder:3.5.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven:maven-core:3.5.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven:maven-plugin-api:3.5.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven.shared:maven-shared-utils:3.2.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.inject:guice:no_aop:4.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: aopalliance:aopalliance:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: javax.annotation:jsr250-api:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.codehaus.plexus:plexus-classworlds:2.5.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-cli:commons-cli:1.4" level="project" />
     <orderEntry type="library" name="Maven: io.quarkus:quarkus-resteasy:0.13.1" level="project" />
     <orderEntry type="library" name="Maven: io.quarkus:quarkus-core:0.13.1" level="project" />
     <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
@@ -92,6 +149,17 @@
     <orderEntry type="library" name="Maven: io.quarkus:quarkus-caffeine:0.13.1" level="project" />
     <orderEntry type="library" name="Maven: io.quarkus:quarkus-jdbc-postgresql:0.13.1" level="project" />
     <orderEntry type="library" name="Maven: org.postgresql:postgresql:42.2.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-test-h2:0.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-test-common:0.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-core-deployment:0.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-beanutils:commons-beanutils-core:1.8.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.invocation:jboss-invocation:1.5.2.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.classfilewriter:jboss-classfilewriter:1.2.4.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus.gizmo:gizmo:1.0.0.Alpha3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:6.2.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-builder:0.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-jsonp-deployment:0.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.197" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-junit5:0.13.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-bootstrap-core:0.13.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven:maven-settings-builder:3.5.4" level="project" />
@@ -123,15 +191,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven.resolver:maven-resolver-transport-file:1.1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven.resolver:maven-resolver-transport-http:1.1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:jcl-over-slf4j:1.7.25" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-test-common:0.13.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-core-deployment:0.13.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-beanutils:commons-beanutils-core:1.8.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.invocation:jboss-invocation:1.5.2.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.classfilewriter:jboss-classfilewriter:1.2.4.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus.gizmo:gizmo:1.0.0.Alpha3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:6.2.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-builder:0.13.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.quarkus:quarkus-jsonp-deployment:0.13.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.4.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.0.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.1.1" level="project" />

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/quarkus/centos-quarkus-maven:graalvm-1.0.0-rc15 AS build
 COPY src /usr/src/app/src
 COPY pom.xml /usr/src/app
 # we will build a native image using the native maven profile
-RUN mvn -f /usr/src/app/pom.xml -DskipTests -Pnative clean package
+RUN mvn -f /usr/src/app/pom.xml -Pnative clean package
 
 ## Stage 2 : create the docker final image form a distroless image !
 FROM cescoffier/native-base

--- a/src/test/java/fr/loicmathieu/demo/quarkus/rest/NativePersonRestIT.java
+++ b/src/test/java/fr/loicmathieu/demo/quarkus/rest/NativePersonRestIT.java
@@ -1,4 +1,4 @@
-package fr.loicmathieu.demo.quarkus.res;
+package fr.loicmathieu.demo.quarkus.rest;
 
 import io.quarkus.test.junit.SubstrateTest;
 

--- a/src/test/java/fr/loicmathieu/demo/quarkus/rest/PersonRestTest.java
+++ b/src/test/java/fr/loicmathieu/demo/quarkus/rest/PersonRestTest.java
@@ -1,12 +1,15 @@
-package fr.loicmathieu.demo.quarkus.res;
+package fr.loicmathieu.demo.quarkus.rest;
 
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
+@QuarkusTestResource(H2DatabaseTestResource.class)
 public class PersonRestTest {
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+# configure your datasource
+quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.driver=org.h2.Driver
+
+# drop and create the database at startup (use `update` to only update the schema)
+quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
Before this PR we had to skip tests during the build by using multistage dockerfile.

Now we can run unit tests by using an H2 database ran at test-time.

I took the opportunity of this PR to correct the package name in src/test/java:  
fr.loicmathieu.demo.quarkus.res => fr.loicmathieu.demo.quarkus.res**t**